### PR TITLE
feat(map): replay historical status colours polygon + mobile UI fixes

### DIFF
--- a/frontend/src/components/MapLegend.jsx
+++ b/frontend/src/components/MapLegend.jsx
@@ -67,7 +67,7 @@ export default function MapLegend({ lastUpdated, demoMode }) {
         onClick={() => setOpen(true)}
         aria-label="Show status legend"
         aria-expanded="false"
-        className="absolute z-20 top-14 left-4 mt-2
+        className="absolute z-20 top-2 left-4
                    w-11 h-11 flex items-center justify-center
                    bg-gray-900/85 backdrop-blur-md border border-gray-700
                    rounded-lg cursor-pointer
@@ -80,7 +80,7 @@ export default function MapLegend({ lastUpdated, demoMode }) {
 
   return (
     <div
-      className="absolute z-20 top-14 left-4 mt-2
+      className="absolute z-20 top-2 left-4
                  bg-gray-900/85 backdrop-blur-md border border-gray-700
                  rounded-lg p-2.5 select-none
                  w-44"

--- a/frontend/src/pages/Overview.jsx
+++ b/frontend/src/pages/Overview.jsx
@@ -353,6 +353,9 @@ export default function Overview() {
     const statusByRegion = Object.fromEntries(
       regionStatuses.map(s => [s.region_id, s.status])
     );
+    if (selectedRegion && displayedAssessment?.replay && displayedAssessment?.status) {
+      statusByRegion[selectedRegion.id] = displayedAssessment.status;
+    }
     return {
       ...REGIONS_GEOJSON,
       features: REGIONS_GEOJSON.features.map(f => {
@@ -367,7 +370,7 @@ export default function Overview() {
         };
       }),
     };
-  }, [regionStatuses]);
+  }, [regionStatuses, selectedRegion, displayedAssessment]);
 
   // ── Painted municipalities ──────────────────────────────────────────────
   // Same shared snapshot as oblasts — cron writes both into HydroTwinStatus
@@ -377,6 +380,9 @@ export default function Overview() {
     const statusByGid = Object.fromEntries(
       regionStatuses.map(s => [s.region_id, s.status])
     );
+    if (selectedRegion && displayedAssessment?.replay && displayedAssessment?.status) {
+      statusByGid[selectedRegion.id] = displayedAssessment.status;
+    }
     return {
       ...MUNICIPALITIES_GEOJSON,
       features: MUNICIPALITIES_GEOJSON.features.map(f => {
@@ -385,7 +391,7 @@ export default function Overview() {
         return { ...f, properties: { ...f.properties, ...extra } };
       }),
     };
-  }, [regionStatuses]);
+  }, [regionStatuses, selectedRegion, displayedAssessment]);
 
   // ── Live /assess fetch ──────────────────────────────────────────────────
   const fetchAssessment = useCallback(async (region) => {
@@ -702,10 +708,11 @@ export default function Overview() {
 
       {!selectedRegion && !isLoading && (
         <div
-          className="absolute bottom-6 left-1/2 -translate-x-1/2 z-20
+          className="absolute left-1/2 -translate-x-1/2 z-20
                      bg-gray-900/85 border border-gray-700 backdrop-blur-sm
                      text-gray-400 text-xs px-5 py-2.5 rounded-full
                      pointer-events-none select-none"
+          style={{ bottom: 'calc(1.5rem + env(safe-area-inset-bottom, 0px))' }}
         >
           Tap a region to view assessment
         </div>


### PR DESCRIPTION
- paintedRegions and paintedMunicipalities now override the selected region colour with the historical status during curated-event and archive-date replay (displayedAssessment.replay flag); reverts to live snapshot automatically when replay is cleared
- Bottom hint bar uses env(safe-area-inset-bottom) so it stays above Android nav bar and iPhone home indicator on all viewports
- MapLegend collapsed chip and open panel moved from top-14 mt-2 to top-2 so the legend sits directly below the TopBar edge